### PR TITLE
Allow a custom filter to be used / injected.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -320,6 +320,21 @@ Hugepages mount point for libvirt.
         - path: /mnt/hugepages_1GB
         - path: /mnt/hugepages_2MB
 
+Custom Scheduler filters
+------------------------
+
+If you have a custom filter, that needs to be included in the scheduler, then you can include it like so:
+
+.. code-block:: yaml
+
+  nova:
+    controller:
+      scheduler_custom_filters:
+      - my_custom_driver.nova.scheduler.filters.my_custom_filter.MyCustomFilter
+
+      # Then add your custom filter on the end (make sure to include all other ones that you need as well)
+      scheduler_default_filters: "DifferentHostFilter,RetryFilter,AvailabilityZoneFilter,RamFilter,CoreFilter,DiskFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,MyCustomFilter"
+
 
 Documentation and Bugs
 ======================

--- a/nova/files/mitaka/nova-controller.conf.Debian
+++ b/nova/files/mitaka/nova-controller.conf.Debian
@@ -22,6 +22,9 @@ disk_allocation_ratio = {{ controller.disk_allocation_ratio }}
 scheduler_default_filters = {{ controller.scheduler_default_filters }}
 scheduler_available_filters = nova.scheduler.filters.all_filters
 scheduler_available_filters = nova.scheduler.filters.pci_passthrough_filter.PciPassthroughFilter
+{% for filter in controller.get('scheduler_custom_filters', []) %}
+scheduler_available_filters = {{ filter }}
+{% endif %}
 scheduler_driver = filter_scheduler
 allow_resize_to_same_host = True
 osapi_max_limit = {{ controller.osapi_max_limit|default('1000') }}


### PR DESCRIPTION
Hi,

I have no idea if this is the correct way to attack this, but i basically want to add a custom filter, which is not covered by the filters provided by OpenStack just yet.

For example, i would like to add the following:
<pre>scheduler_available_filters = openstack_drift.nova.scheduler.filters.aggregate_exclusive_image_properties.AggregateExclusiveImageProperties</pre>

In that code i have a scheduler filter, that works similar to AggregateImagePropertiesIsolation, but then just a little bit differently. The main goal of that filter is to separate all windows instances in a separate pool, because of Microsoft licensing terms, which states that you have to license all nodes where windows vm's are running on. This will keep our resources contained within a aggregate, which is not in the default set of OpenStack Nova scheduler filters.

So, how do we implement a custom fitler; based on given proposal, or in a different way?
