### PR TITLE
Fix metdata password for cluster and containers

### DIFF
--- a/metadata/service/control/cluster.yml
+++ b/metadata/service/control/cluster.yml
@@ -61,7 +61,7 @@ parameters:
         port: 9696
         mtu: 1500
       metadata:
-        password: metadataPass
+        password: ${_param:metadata_password}
       cache:
         engine: memcached
         members:

--- a/metadata/service/control/container.yml
+++ b/metadata/service/control/container.yml
@@ -61,4 +61,4 @@ parameters:
                   port: 9696
                   mtu: 1500
                 metadata:
-                  password: ${_param:nova_metadata_password}
+                  password: ${_param:metadata_password}


### PR DESCRIPTION
There were three ways the deafult for this parameter was defined:
    cluster:
        password: metadataPass
    container:
        password: ${_param:nova_metadata_password}
    single:
        password: ${_param:metadata_password}

Between "nova_metadata_password" and "metadata_password",
"metadata_password" seems better because this password is intentionally
shared between nova and neturon, and it should not be different between
the two.  Standardize all three service roles to use the same default.