### PR TITLE
Cleanup nova-compute configs

### DIFF
--- a/nova/files/mitaka/nova-compute.conf.Debian
+++ b/nova/files/mitaka/nova-compute.conf.Debian
@@ -13,7 +13,6 @@ network_device_mtu=65000
 use_neutron = True
 config_drive_format=vfat
 force_config_drive=True
-allow_resize_to_same_host=True
 security_group_api=neutron
 vif_plugging_is_fatal=True
 vif_plugging_timeout=300
@@ -168,8 +167,7 @@ rabbit_retry_interval = 1
 rabbit_retry_backoff = 2
 
 [glance]
-api_servers={{ compute.image.host }}:9292
-host={{ compute.image.host }}
+api_servers=http://{{ compute.image.host }}:9292
 
 [neutron]
 username={{ compute.network.user }}

--- a/nova/files/newton/nova-compute.conf.Debian
+++ b/nova/files/newton/nova-compute.conf.Debian
@@ -15,7 +15,6 @@ config_drive_format=vfat
 force_config_drive=True
 force_raw_images=True
 notify_api_faults=False
-allow_resize_to_same_host=True
 security_group_api=neutron
 vif_plugging_is_fatal=True
 vif_plugging_timeout=300
@@ -167,8 +166,7 @@ memcached_servers={%- for member in compute.cache.members %}{{ member.host }}:11
 
 
 [glance]
-api_servers={{ compute.image.host }}:9292
-host={{ compute.image.host }}
+api_servers=http://{{ compute.image.host }}:9292
 
 [neutron]
 username={{ compute.network.user }}

--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -5003,7 +5003,7 @@ catalog_info=volumev2:cinderv2:internalURL
 #   (i.e. "http://10.0.1.0:9292" or "https://my.glance.server/image").
 #  (list value)
 #api_servers=<None>
-api_servers={{ compute.image.host }}:9292
+api_servers=http://{{ compute.image.host }}:9292
 
 #
 # Enable insecure SSL (https) requests to glance.


### PR DESCRIPTION
[glance]/hosts is deprecated in favor of the api_servers option.
[glance]/api_servers should be the fully qualified url including the scheme.
  Updating this prevents lots of warnings in log output.

[DEFAULT]/allow_resize_to_same_host was duplicated on some versions of
nova-compute.conf.