### PR TITLE
Allow overriding the  scheduler_host_manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -399,6 +399,18 @@ In order to actually utilize this feature, the following metadata must be set on
   glance image-update --property hw_scsi_model=virtio-scsi <image>
   glance image-update --property hw_disk_bus=scsi <image>
 
+Scheduler Host Manager
+----------------------
+
+Specify a custom host manager.
+
+.. code-block:: yaml
+
+  nova:
+    controller:
+      scheduler_host_manager: ironic_host_manager
+
+
 Documentation and Bugs
 ======================
 

--- a/nova/files/newton/nova-controller.conf.Debian
+++ b/nova/files/newton/nova-controller.conf.Debian
@@ -21,7 +21,6 @@ ram_allocation_ratio = {{ controller.ram_allocation_ratio }}
 disk_allocation_ratio = {{ controller.disk_allocation_ratio }}
 scheduler_default_filters = {{ controller.scheduler_default_filters }}
 scheduler_available_filters = nova.scheduler.filters.all_filters
-scheduler_available_filters = nova.scheduler.filters.pci_passthrough_filter.PciPassthroughFilter
 {% for filter in controller.get('scheduler_custom_filters', []) %}
 scheduler_available_filters = {{ filter }}
 {% endfor %}
@@ -38,7 +37,7 @@ max_age=0
 scheduler_max_attempts=3
 max_io_ops_per_host=8
 max_instances_per_host=50
-scheduler_host_manager=host_manager
+scheduler_host_manager={{ controller.get('scheduler_host_manager', 'host_manager') }}
 use_forwarded_for=False
 reservation_expire=86400
 compute_driver = nova.virt.libvirt.LibvirtDriver


### PR DESCRIPTION
Deployments with Ironic need a custom host manager. Allow overriding it.

Don't add PciPassthroughFilter explicitly to the active filters.
Some releases of Nova have a bug using this filter with the 
ironic scheduler_host_manager.
nova.scheduler.filters.all_filters should include this if it's in the
default filters (as it is in metadata/service/control/cluster.yml), 
and if it is removed from scheduler_default_filters in
the pillar, the new scheduler_custom_filters will allow users to
manually add it.