### PR TITLE
because of stacklight, every node in our deployment has neutron defined

### DIFF
--- a/nova/files/mitaka/nova-controller.conf.Debian
+++ b/nova/files/mitaka/nova-controller.conf.Debian
@@ -184,7 +184,7 @@ auth_type = password
 project_domain_name = default
 user_domain_name = default
 auth_url = http://{{ controller.identity.host }}:35357
-{% if pillar.neutron is defined %}
+{% if pillar.neutron is defined and pillar.neutron.server is defined %}
 password={{ pillar.neutron.server.identity.password }}
 project_name={{ pillar.neutron.server.identity.tenant }}
 username={{ pillar.neutron.server.identity.user }}

--- a/nova/files/newton/nova-controller.conf.Debian
+++ b/nova/files/newton/nova-controller.conf.Debian
@@ -194,7 +194,7 @@ auth_type=v3password
 project_domain_name = Default
 user_domain_name = Default
 auth_url = http://{{ controller.identity.host }}:35357/v3
-{% if pillar.neutron is defined %}
+{% if pillar.neutron is defined and pillar.neutron.server is defined %}
 password={{ pillar.neutron.server.identity.password }}
 project_name={{ pillar.neutron.server.identity.tenant }}
 username={{ pillar.neutron.server.identity.user }}

--- a/nova/files/ocata/nova-controller.conf.Debian
+++ b/nova/files/ocata/nova-controller.conf.Debian
@@ -7070,7 +7070,7 @@ auth_type=v3password
 project_domain_name = Default
 user_domain_name = Default
 auth_url = http://{{ controller.identity.host }}:35357/v3
-{% if pillar.neutron is defined %}
+{% if pillar.neutron is defined and pillar.neutron.server is defined %}
 password={{ pillar.neutron.server.identity.password }}
 project_name={{ pillar.neutron.server.identity.tenant }}
 username={{ pillar.neutron.server.identity.user }}


### PR DESCRIPTION
(with sensu support disabled).

This check makes sure the server part is defined.

example pillar defined everywhere:
>   - neutron:
>     - _support:
>       - sensu:
>         - enabled: false
> 