### PR TITLE
Add configurable workaround to enable live snapshots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -437,7 +437,7 @@ Configurable pillar data:
 
   nova:
     compute:
-      workarounds:
+      workaround:
         disable_libvirt_livesnapshot: False
 
 

--- a/README.rst
+++ b/README.rst
@@ -412,6 +412,34 @@ things. Defaults to host-passthrough.
     compute:
       cpu_mode: host-model
 
+Nova compute workarounds
+------------------------
+
+Live snapshotting is disabled by default in nova. To enable this, it needs a manual switch.
+
+From manual:
+
+.. code-block:: yaml
+
+  # When using libvirt 1.2.2 live snapshots fail intermittently under load
+  # (likely related to concurrent libvirt/qemu operations). This config
+  # option provides a mechanism to disable live snapshot, in favor of cold
+  # snapshot, while this is resolved. Cold snapshot causes an instance
+  # outage while the guest is going through the snapshotting process.
+  #
+  # For more information, refer to the bug report:
+  #
+  #   https://bugs.launchpad.net/nova/+bug/1334398
+
+Configurable pillar data:
+
+.. code-block:: yaml
+
+  nova:
+    compute:
+      workarounds:
+        disable_libvirt_livesnapshot: False
+
 
 Documentation and Bugs
 ======================

--- a/nova/files/mitaka/nova-compute.conf.Debian
+++ b/nova/files/mitaka/nova-compute.conf.Debian
@@ -186,5 +186,7 @@ timeout=30
 os_region_name = {{ compute.identity.region }}
 catalog_info=volumev2:cinderv2:internalURL
 
+{%- if compute.workaround is defined %}
 [workarounds]
-disable_libvirt_livesnapshot={{ compute.get('workarounds', {}).get('disable_libvirt_livesnapshot', True)|lower }}
+disable_libvirt_livesnapshot={{ compute.workaround.get('disable_libvirt_livesnapshot', True)|lower }}
+{%- endif %}

--- a/nova/files/mitaka/nova-compute.conf.Debian
+++ b/nova/files/mitaka/nova-compute.conf.Debian
@@ -186,3 +186,5 @@ timeout=30
 os_region_name = {{ compute.identity.region }}
 catalog_info=volumev2:cinderv2:internalURL
 
+[workarounds]
+disable_libvirt_livesnapshot={{ compute.get('workarounds', {}).get('disable_libvirt_livesnapshot', True)|lower }}

--- a/nova/files/newton/nova-compute.conf.Debian
+++ b/nova/files/newton/nova-compute.conf.Debian
@@ -202,5 +202,7 @@ user_domain_name={{ compute.ironic.get('user_domain_name', 'Default') }}
 password={{ compute.ironic.password }}
 {%- endif %}
 
+{%- if compute.workaround is defined %}
 [workarounds]
-disable_libvirt_livesnapshot={{ compute.get('workarounds', {}).get('disable_libvirt_livesnapshot', True)|lower }}
+disable_libvirt_livesnapshot={{ compute.workaround.get('disable_libvirt_livesnapshot', True)|lower }}
+{%- endif %}

--- a/nova/files/newton/nova-compute.conf.Debian
+++ b/nova/files/newton/nova-compute.conf.Debian
@@ -201,3 +201,6 @@ username={{ compute.ironic.user }}
 user_domain_name={{ compute.ironic.get('user_domain_name', 'Default') }}
 password={{ compute.ironic.password }}
 {%- endif %}
+
+[workarounds]
+disable_libvirt_livesnapshot={{ compute.get('workarounds', {}).get('disable_libvirt_livesnapshot', True)|lower }}

--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -10059,7 +10059,7 @@ keymap = {{ compute.get('vnc_keymap', 'en-us') }}
 #   there is a new enough libvirt and the backend storage supports it)
 #  (boolean value)
 #disable_libvirt_livesnapshot=true
-disable_libvirt_livesnapshot={{ compute.get('workarounds', {}).get('disable_libvirt_livesnapshot', True)|lower }}
+disable_libvirt_livesnapshot={{ compute.get('workaround', {}).get('disable_libvirt_livesnapshot', True)|lower }}
 
 #
 # Enable handling of events emitted from compute drivers.

--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -10059,6 +10059,7 @@ keymap = {{ compute.get('vnc_keymap', 'en-us') }}
 #   there is a new enough libvirt and the backend storage supports it)
 #  (boolean value)
 #disable_libvirt_livesnapshot=true
+disable_libvirt_livesnapshot={{ compute.get('workarounds', {}).get('disable_libvirt_livesnapshot', True)|lower }}
 
 #
 # Enable handling of events emitted from compute drivers.


### PR DESCRIPTION
Issue should be fixed in Ubuntu 16.04 with libvirt 1.3.1, so lets make this configurable.