### PR TITLE
Block device creation timeout

### DIFF
--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -10520,6 +10520,9 @@ api_paste_config=/etc/nova/api-paste.ini
 # Time in secs to wait for a block device to be created (integer value)
 # Minimum value: 1
 #block_device_creation_timeout=10
+{%- if compute.block_device_creation_timeout is defined %}
+block_device_creation_timeout = {{ compute.block_device_creation_timeout }}
+{%- else  %}
 
 #
 # Maximum size in bytes of kernel or ramdisk images.

--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -10522,7 +10522,7 @@ api_paste_config=/etc/nova/api-paste.ini
 #block_device_creation_timeout=10
 {%- if compute.block_device_creation_timeout is defined %}
 block_device_creation_timeout = {{ compute.block_device_creation_timeout }}
-{%- else  %}
+{%- endif  %}
 
 #
 # Maximum size in bytes of kernel or ramdisk images.

--- a/nova/files/ocata/nova-controller.conf.Debian
+++ b/nova/files/ocata/nova-controller.conf.Debian
@@ -10529,7 +10529,7 @@ api_paste_config=/etc/nova/api-paste.ini
 #block_device_creation_timeout=10
 {%- if controller.block_device_creation_timeout is defined %}
 block_device_creation_timeout = {{ controller.block_device_creation_timeout }}
-{%- else  %}
+{%- endif  %}
 
 #
 # Maximum size in bytes of kernel or ramdisk images.

--- a/nova/files/ocata/nova-controller.conf.Debian
+++ b/nova/files/ocata/nova-controller.conf.Debian
@@ -10527,6 +10527,9 @@ api_paste_config=/etc/nova/api-paste.ini
 # Time in secs to wait for a block device to be created (integer value)
 # Minimum value: 1
 #block_device_creation_timeout=10
+{%- if controller.block_device_creation_timeout is defined %}
+block_device_creation_timeout = {{ controller.block_device_creation_timeout }}
+{%- else  %}
 
 #
 # Maximum size in bytes of kernel or ramdisk images.


### PR DESCRIPTION
Parametrize block_device_creation_timeout because of conversion from QCOW2 to RAW can take more time when provisioning to RBD.