### PR TITLE
Added Keystone V3 support for Debian.

### DIFF
--- a/nova/files/mitaka/nova-compute.conf.Debian
+++ b/nova/files/mitaka/nova-compute.conf.Debian
@@ -166,8 +166,10 @@ auth_url=http://{{ compute.identity.host }}:35357
 {%- if compute.cache is defined %}
 memcached_servers={%- for member in compute.cache.members %}{{ member.host }}:11211{% if not loop.last %},{% endif %}{%- endfor %}
 {%- endif %}
-{%- if compute.identity.auth_version is defined %}
-auth_version={{ compute.identity.auth_version }}
+{%- if pillar.keystone.server.api_version is defined %}
+auth_version={{ pillar.keystone.server.api_version }}
+{%- else %}
+#auth_version=<None>
 {%- endif %}
 
 [oslo_messaging_rabbit]

--- a/nova/files/mitaka/nova-compute.conf.Debian
+++ b/nova/files/mitaka/nova-compute.conf.Debian
@@ -166,6 +166,9 @@ auth_url=http://{{ compute.identity.host }}:35357
 {%- if compute.cache is defined %}
 memcached_servers={%- for member in compute.cache.members %}{{ member.host }}:11211{% if not loop.last %},{% endif %}{%- endfor %}
 {%- endif %}
+{%- if compute.identity.auth_version is defined %}
+auth_version={{ compute.identity.auth_version }}
+{%- endif %}
 
 [oslo_messaging_rabbit]
 {%- if compute.message_queue.members is defined %}

--- a/nova/files/mitaka/nova-controller.conf.Debian
+++ b/nova/files/mitaka/nova-controller.conf.Debian
@@ -145,8 +145,10 @@ auth_url=http://{{ controller.identity.host }}:35357
 {%- if controller.cache is defined %}
 memcached_servers={%- for member in controller.cache.members %}{{ member.host }}:11211{% if not loop.last %},{% endif %}{%- endfor %}
 {%- endif %}
-{%- if controller.identity.auth_version is defined %}
-auth_version={{ controller.identity.auth_version }}
+{%- if pillar.keystone.server.api_version is defined %}
+auth_version={{ pillar.keystone.server.api_version }}
+{%- else %}
+#auth_version=<None>
 {%- endif %}
 
 [conductor]

--- a/nova/files/mitaka/nova-controller.conf.Debian
+++ b/nova/files/mitaka/nova-controller.conf.Debian
@@ -145,6 +145,9 @@ auth_url=http://{{ controller.identity.host }}:35357
 {%- if controller.cache is defined %}
 memcached_servers={%- for member in controller.cache.members %}{{ member.host }}:11211{% if not loop.last %},{% endif %}{%- endfor %}
 {%- endif %}
+{%- if controller.identity.auth_version is defined %}
+auth_version={{ controller.identity.auth_version }}
+{%- endif %}
 
 [conductor]
 workers = {{ controller.workers }}

--- a/nova/files/newton/nova-compute.conf.Debian
+++ b/nova/files/newton/nova-compute.conf.Debian
@@ -191,8 +191,10 @@ auth_url=http://{{ compute.identity.host }}:35357
 {%- if compute.cache is defined %}
 memcached_servers={%- for member in compute.cache.members %}{{ member.host }}:11211{% if not loop.last %},{% endif %}{%- endfor %}
 {%- endif %}
-{%- if compute.identity.auth_version is defined %}
-auth_version={{ compute.identity.auth_version }}
+{%- if pillar.keystone.server.api_version is defined %}
+auth_version={{ pillar.keystone.server.api_version }}
+{%- else %}
+#auth_version=<None>
 {%- endif %}
 
 [oslo_messaging_rabbit]

--- a/nova/files/newton/nova-compute.conf.Debian
+++ b/nova/files/newton/nova-compute.conf.Debian
@@ -191,6 +191,9 @@ auth_url=http://{{ compute.identity.host }}:35357
 {%- if compute.cache is defined %}
 memcached_servers={%- for member in compute.cache.members %}{{ member.host }}:11211{% if not loop.last %},{% endif %}{%- endfor %}
 {%- endif %}
+{%- if compute.identity.auth_version is defined %}
+auth_version={{ compute.identity.auth_version }}
+{%- endif %}
 
 [oslo_messaging_rabbit]
 

--- a/nova/files/newton/nova-controller.conf.Debian
+++ b/nova/files/newton/nova-controller.conf.Debian
@@ -152,8 +152,10 @@ auth_url=http://{{ controller.identity.host }}:35357
 {%- if controller.cache is defined %}
 memcached_servers={%- for member in controller.cache.members %}{{ member.host }}:11211{% if not loop.last %},{% endif %}{%- endfor %}
 {%- endif %}
-{%- if controller.identity.auth_version is defined %}
-auth_version={{ controller.identity.auth_version }}
+{%- if pillar.keystone.server.api_version is defined %}
+auth_version={{ pillar.keystone.server.api_version }}
+{%- else %}
+#auth_version=<None>
 {%- endif %}
 
 [conductor]

--- a/nova/files/newton/nova-controller.conf.Debian
+++ b/nova/files/newton/nova-controller.conf.Debian
@@ -152,6 +152,9 @@ auth_url=http://{{ controller.identity.host }}:35357
 {%- if controller.cache is defined %}
 memcached_servers={%- for member in controller.cache.members %}{{ member.host }}:11211{% if not loop.last %},{% endif %}{%- endfor %}
 {%- endif %}
+{%- if controller.identity.auth_version is defined %}
+auth_version={{ controller.identity.auth_version }}
+{%- endif %}
 
 [conductor]
 workers = {{ controller.workers }}

--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -5692,9 +5692,10 @@ memcached_servers={%- for member in compute.cache.members %}{{ member.host }}:11
 #auth_uri=<None>
 
 # API version of the admin Identity API endpoint. (string value)
+{%- if pillar.keystone.server.api_version is defined %}
+auth_version={{ pillar.keystone.server.api_version }}
+{%- else %}
 #auth_version=<None>
-{%- if compute.identity.auth_version is defined %}
-auth_version={{ compute.identity.auth_version }}
 {%- endif %}
 
 # Do not handle authorization requests within the middleware, but delegate the

--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -5693,6 +5693,9 @@ memcached_servers={%- for member in compute.cache.members %}{{ member.host }}:11
 
 # API version of the admin Identity API endpoint. (string value)
 #auth_version=<None>
+{%- if compute.identity.auth_version is defined %}
+auth_version={{ compute.identity.auth_version }}
+{%- endif %}
 
 # Do not handle authorization requests within the middleware, but delegate the
 # authorization decision to downstream WSGI components. (boolean value)

--- a/nova/files/ocata/nova-controller.conf.Debian
+++ b/nova/files/ocata/nova-controller.conf.Debian
@@ -5708,6 +5708,9 @@ memcached_servers={%- for member in controller.cache.members %}{{ member.host }}
 
 # API version of the admin Identity API endpoint. (string value)
 #auth_version=<None>
+{%- if controller.identity.auth_version is defined %}
+auth_version={{ controller.identity.auth_version }}
+{%- endif %}
 
 # Do not handle authorization requests within the middleware, but delegate the
 # authorization decision to downstream WSGI components. (boolean value)

--- a/nova/files/ocata/nova-controller.conf.Debian
+++ b/nova/files/ocata/nova-controller.conf.Debian
@@ -5707,9 +5707,10 @@ memcached_servers={%- for member in controller.cache.members %}{{ member.host }}
 #auth_uri=<None>
 
 # API version of the admin Identity API endpoint. (string value)
+{%- if pillar.keystone.server.api_version is defined %}
+auth_version={{ pillar.keystone.server.api_version }}
+{%- else %}
 #auth_version=<None>
-{%- if controller.identity.auth_version is defined %}
-auth_version={{ controller.identity.auth_version }}
 {%- endif %}
 
 # Do not handle authorization requests within the middleware, but delegate the


### PR DESCRIPTION
Keystone V3 can be enabled in Keystone salt formula, but to use it in Nova need to enable auth_version to use V3. For Redhat it is enabled and configured, people who are using Ubuntu or Debian it was not enabled on Mitaka, Newton and Ocata.