### PR TITLE
Make inbound migration address configurable

### DIFF
--- a/nova/files/mitaka/nova-compute.conf.Debian
+++ b/nova/files/mitaka/nova-compute.conf.Debian
@@ -122,6 +122,9 @@ disk_cachemodes="{{ compute.get('disk_cachemodes', 'network=writeback,block=none
 libvirt_inject_password=True
 block_migration_flag=VIR_MIGRATE_UNDEFINE_SOURCE,VIR_MIGRATE_PEER2PEER,VIR_MIGRATE_LIVE,VIR_MIGRATE_NON_SHARED_INC
 live_migration_flag=VIR_MIGRATE_UNDEFINE_SOURCE,VIR_MIGRATE_PEER2PEER,VIR_MIGRATE_LIVE,VIR_MIGRATE_PERSIST_DEST
+{%- if compute.libvirt.migration_inbound_addr is defined %}
+live_migration_inbound_addr = {{ compute.libvirt.migration_inbound_addr }}
+{%- endif %}
 libvirt_inject_key=True
 inject_key=False
 vif_driver=nova.virt.libvirt.vif.LibvirtGenericVIFDriver

--- a/nova/files/newton/nova-compute.conf.Debian
+++ b/nova/files/newton/nova-compute.conf.Debian
@@ -165,6 +165,9 @@ disk_cachemodes="{{ compute.get('disk_cachemodes', 'network=writeback,block=none
 libvirt_inject_password=True
 block_migration_flag=VIR_MIGRATE_UNDEFINE_SOURCE,VIR_MIGRATE_PEER2PEER,VIR_MIGRATE_LIVE,VIR_MIGRATE_NON_SHARED_INC
 live_migration_flag=VIR_MIGRATE_UNDEFINE_SOURCE,VIR_MIGRATE_PEER2PEER,VIR_MIGRATE_LIVE,VIR_MIGRATE_PERSIST_DEST
+{%- if compute.libvirt.migration_inbound_addr is defined %}
+live_migration_inbound_addr = {{ compute.libvirt.migration_inbound_addr }}
+{%- endif %}
 libvirt_inject_key=True
 inject_key=False
 vif_driver=nova.virt.libvirt.vif.LibvirtGenericVIFDriver

--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -6147,6 +6147,9 @@ connection_uri={{ compute.libvirt.uri }}
 # * A valid IP address or hostname, else None.
 #  (string value)
 #live_migration_inbound_addr=<None>
+{%- if compute.libvirt.migration_inbound_addr is defined %}
+live_migration_inbound_addr = {{ compute.libvirt.migration_inbound_addr }}
+{%- endif %}
 
 # DEPRECATED:
 # Live migration target URI to use.


### PR DESCRIPTION
This allows us to make sure all migrations flow over
a 10Gbit connection instead of a slower 1Gbit connection
by defining the correct IP address