### PR TITLE
Dhcp domain option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Nova services on the controller node
         cross_az_attach: false
         workers: 8
         report_interval: 60
+        dhcp_domain: novalocal
         bind:
           public_address: 10.0.0.122
           public_name: openstack.domain.com

--- a/nova/files/mitaka/nova-controller.conf.Debian
+++ b/nova/files/mitaka/nova-controller.conf.Debian
@@ -12,6 +12,9 @@ volumes_dir = /etc/nova/volumes
 dhcpbridge = /usr/bin/nova-dhcpbridge
 dhcpbridge_flagfile = /etc/nova/nova.conf
 force_dhcp_release = True
+{%- if controller.dhcp_domain is defined %}
+dhcp_domain = {{ controller.dhcp_domain }}
+{%- endif %}
 injected_network_template = /usr/share/nova/interfaces.template
 libvirt_nonblocking = True
 vif_plugging_is_fatal = False

--- a/nova/files/newton/nova-controller.conf.Debian
+++ b/nova/files/newton/nova-controller.conf.Debian
@@ -12,6 +12,9 @@ volumes_dir = /etc/nova/volumes
 dhcpbridge = /usr/bin/nova-dhcpbridge
 dhcpbridge_flagfile = /etc/nova/nova.conf
 force_dhcp_release = True
+{%- if controller.dhcp_domain is defined %}
+dhcp_domain = {{ controller.dhcp_domain }}
+{%- endif %}
 injected_network_template = /usr/share/nova/interfaces.template
 libvirt_nonblocking = True
 vif_plugging_is_fatal = False

--- a/nova/files/ocata/nova-controller.conf.Debian
+++ b/nova/files/ocata/nova-controller.conf.Debian
@@ -2267,6 +2267,9 @@ force_dhcp_release=true
 # Reason:
 # nova-network is deprecated, as are any related configuration options.
 #dhcp_domain=novalocal
+{%- if controller.dhcp_domain is defined %}
+dhcp_domain = {{ controller.dhcp_domain }}
+{%- endif %}
 
 # DEPRECATED:
 # This option allows you to specify the L3 management library to be used.


### PR DESCRIPTION
Make dhcp_domain configurable

It is already in the default reclass (for example in file metadata/control/cluster.yml), but it was not applied in controller configuration file.

It will apply to the nova metadata server. (hostname part)