### PR TITLE
Add option max_concurrent_live_migrations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -618,6 +618,32 @@ See example below on how to configure the options for the config drive.
         format: iso9660  # Default: vfat
         inject_password: False  # Default: False
 
+Number of concurrent live migrates
+----------------------------------
+
+Default is to have no concurrent live migrations (so 1 live-migration at a time).
+
+Excerpt from config options page (https://docs.openstack.org/ocata/config-reference/compute/config-options.html):
+
+  Maximum number of live migrations to run concurrently. This limit is
+  enforced to avoid outbound live migrations overwhelming the host/network
+  and causing failures. It is not recommended that you change this unless
+  you are very sure that doing so is safe and stable in your environment.
+
+  Possible values:
+
+  - 0 : treated as unlimited.
+  - Negative value defaults to 0.
+  - Any positive integer representing maximum number of live migrations to run concurrently.
+
+To configure this option:
+
+.. code-block:: yaml
+
+  nova:
+    compute:
+      max_concurrent_live_migrations: 1  # (1 is the default)
+
 
 Documentation and Bugs
 ======================

--- a/nova/files/mitaka/nova-compute.conf.Debian
+++ b/nova/files/mitaka/nova-compute.conf.Debian
@@ -38,6 +38,10 @@ image_service=nova.image.glance.GlanceImageService
 
 reserved_host_memory_mb = {{ compute.get('reserved_host_memory_mb', '512') }}
 
+{%- if compute.max_concurrent_live_migrations is defined %}
+max_concurrent_live_migrations = {{ compute.max_concurrent_live_migrations }}
+{%- endif %}
+
 {%- if compute.vcpu_pin_set is defined %}
 vcpu_pin_set={{ compute.vcpu_pin_set }}
 {%- endif %}

--- a/nova/files/newton/nova-compute.conf.Debian
+++ b/nova/files/newton/nova-compute.conf.Debian
@@ -40,6 +40,10 @@ image_service=nova.image.glance.GlanceImageService
 
 reserved_host_memory_mb = {{ compute.get('reserved_host_memory_mb', '512') }}
 
+{%- if compute.max_concurrent_live_migrations is defined %}
+max_concurrent_live_migrations = {{ compute.max_concurrent_live_migrations }}
+{%- endif %}
+
 {%- if compute.vcpu_pin_set is defined %}
 vcpu_pin_set={{ compute.vcpu_pin_set }}
 {%- endif %}

--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -716,6 +716,9 @@ resume_guests_state_on_host_boot={{ compute.get('resume_guests_state_on_host_boo
 #   to run concurrently.
 #  (integer value)
 #max_concurrent_live_migrations=1
+{%- if compute.max_concurrent_live_migrations is defined %}
+max_concurrent_live_migrations = {{ compute.max_concurrent_live_migrations }}
+{%- endif %}
 
 #
 # Number of times to retry block device allocation on failures. Starting with


### PR DESCRIPTION
To speed up maintenance in a 10Gbit environment, we are configuring nova compute to use more concurrency in live migrations. Therefore we want to add this option.