### PR TITLE
Fix dynamic_ownership parameter in qemu.conf. Needs to be there witho…

### DIFF
--- a/nova/files/ocata/qemu.conf.Debian
+++ b/nova/files/ocata/qemu.conf.Debian
@@ -248,7 +248,7 @@ group = "{{ compute.qemu.group }}"
 {%- endif %}
 
 {%- if compute.qemu.dynamic_ownership is defined %}
-dynamic_ownership = "{{ compute.qemu.dynamic_ownership }}"
+dynamic_ownership = {{ compute.qemu.dynamic_ownership }}
 {%- endif %}
 {%- endif %}
 


### PR DESCRIPTION
…ut quotes. Causes libvirt-bin process to fail with this message:
libvirtd[51573]: internal error: /etc/libvirt/qemu.conf: dynamic_ownership: expected type VIR_CONF_ULONG
libvirtd[51573]: Initialization of QEMU state driver failed: internal error: /etc/libvirt/qemu.conf: dynamic_ownership: expected type VIR_CONF_ULONG
libvirtd[51573]: Driver state initialization failed