### PR TITLE
Make live_migration_permit_auto_converge flag into a parameter to set via reclass

### DIFF
--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -550,6 +550,12 @@ reserved_host_memory_mb = {{ compute.get('reserved_host_memory_mb', '512') }}
 # * Any valid positive integer or float value
 #  (floating point value)
 # Minimum value: 0
+{%- if compute.live_migration_permit_auto_converge is defined %}
+live_migration_permit_auto_converge = {{ compute.live_migration_permit_auto_converge }}
+{%- else  %}
+#live_migration_permit_auto_converge=false
+{%- endif %}
+
 {%- if compute.cpu_allocation_ratio is defined %}
 cpu_allocation_ratio = {{ compute.cpu_allocation_ratio }}
 {%- else  %}
@@ -6383,6 +6389,8 @@ live_migration_tunnelled = {{ compute.libvirt.live_migration_tunnelled }}
 #
 #     * live_migration_permit_post_copy
 #  (boolean value)
+live_migration_permit_auto_converge={{ compute.config.get('live_migration_permit_auto_converge', 'false') }}
+
 #live_migration_permit_auto_converge=false
 
 #

--- a/nova/files/ocata/nova-controller.conf.Debian
+++ b/nova/files/ocata/nova-controller.conf.Debian
@@ -537,6 +537,12 @@ injected_network_template=$pybasedir/nova/virt/interfaces.template
 # * Any valid positive integer or float value
 #  (floating point value)
 # Minimum value: 0
+{%- if controller.live_migration_permit_auto_converge is defined %}
+live_migration_permit_auto_converge = {{ controller.live_migration_permit_auto_converge }}
+{%- else  %}
+#live_migration_permit_auto_converge=false
+{%- endif %}
+
 #cpu_allocation_ratio=0.0
 cpu_allocation_ratio={{ controller.cpu_allocation_ratio }}
 
@@ -6345,6 +6351,7 @@ use_usb_tablet=true
 #     * live_migration_permit_post_copy
 #  (boolean value)
 #live_migration_permit_auto_converge=false
+live_migration_permit_auto_converge={{ controller.config.get('live_migration_permit_auto_converge', 'false') }}
 
 #
 # Determine the snapshot image format when sending to the image service.


### PR DESCRIPTION
We want to enable changing this flag in our MCP clusters deployed via reclass and salt. This will allow us to do this. Default value of this flag is kept as false so there isn't any adverse impact on existing installations.