### PR TITLE
Block device retries missing parameters

### DIFF
--- a/nova/files/juno/nova-compute.conf.Debian
+++ b/nova/files/juno/nova-compute.conf.Debian
@@ -100,8 +100,8 @@ rpc_response_timeout = {{ compute.message_queue.rpc_response_timeout }}
 rpc_thread_pool_size = 70
 report_interval = 5
 
-block_device_allocate_retries=600
-block_device_allocate_retries_interval=10
+block_device_allocate_retries={{ compute.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries_interval={{ compute.get('block_device_allocate_retries_interval', '10') }}
 
 resume_guests_state_on_host_boot = True
 service_down_time = 90

--- a/nova/files/juno/nova-controller.conf.Debian
+++ b/nova/files/juno/nova-controller.conf.Debian
@@ -127,8 +127,8 @@ rpc_response_timeout = {{ controller.message_queue.rpc_response_timeout }}
 rpc_thread_pool_size = 70
 report_interval = 5
 
-block_device_allocate_retries=600
-block_device_allocate_retries_interval=10
+block_device_allocate_retries={{ controller.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries_interval={{ controller.get('block_device_allocate_retries_interval', '10') }}
 
 [keystone_authtoken]
 signing_dirname=/tmp/keystone-signing-nova

--- a/nova/files/kilo/nova-compute.conf.Debian
+++ b/nova/files/kilo/nova-compute.conf.Debian
@@ -89,8 +89,8 @@ rpc_response_timeout = {{ compute.message_queue.rpc_response_timeout }}
 rpc_thread_pool_size = 70
 report_interval = {{ compute.get('report_interval', '60') }}
 
-block_device_allocate_retries=600
-block_device_allocate_retries_interval=10
+block_device_allocate_retries={{ compute.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries_interval={{ compute.get('block_device_allocate_retries_interval', '10') }}
 
 resume_guests_state_on_host_boot = True
 service_down_time = 90

--- a/nova/files/kilo/nova-controller.conf.Debian
+++ b/nova/files/kilo/nova-controller.conf.Debian
@@ -116,8 +116,8 @@ rpc_response_timeout = {{ controller.message_queue.rpc_response_timeout }}
 rpc_thread_pool_size = 70
 report_interval = 5
 
-block_device_allocate_retries=600
-block_device_allocate_retries_interval=10
+block_device_allocate_retries={{ controller.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries_interval={{ controller.get('block_device_allocate_retries_interval', '10') }}
 
 [oslo_concurrency]
 

--- a/nova/files/liberty/nova-compute.conf.Debian
+++ b/nova/files/liberty/nova-compute.conf.Debian
@@ -97,8 +97,8 @@ rpc_response_timeout = {{ compute.message_queue.rpc_response_timeout }}
 rpc_thread_pool_size = 70
 report_interval = {{ compute.get('report_interval', '60') }}
 
-block_device_allocate_retries=600
-block_device_allocate_retries_interval=10
+block_device_allocate_retries={{ compute.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries_interval={{ compute.get('block_device_allocate_retries_interval', '10') }}
 
 resume_guests_state_on_host_boot = {{ compute.get('resume_guests_state_on_host_boot', True) }}
 service_down_time = 90

--- a/nova/files/liberty/nova-controller.conf.Debian
+++ b/nova/files/liberty/nova-controller.conf.Debian
@@ -111,8 +111,8 @@ rpc_response_timeout = {{ controller.message_queue.rpc_response_timeout }}
 rpc_thread_pool_size = 70
 report_interval = 5
 
-block_device_allocate_retries=600
-block_device_allocate_retries_interval=10
+block_device_allocate_retries={{ controller.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries_interval={{ controller.get('block_device_allocate_retries_interval', '10') }}
 
 [oslo_concurrency]
 

--- a/nova/files/mitaka/nova-compute.conf.Debian
+++ b/nova/files/mitaka/nova-compute.conf.Debian
@@ -74,8 +74,8 @@ rpc_response_timeout = {{ compute.message_queue.rpc_response_timeout }}
 executor_thread_pool_size = 70
 report_interval = {{ compute.get('report_interval', '60') }}
 
-block_device_allocate_retries=600
-block_device_allocate_retries_interval=10
+block_device_allocate_retries={{ compute.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries_interval={{ compute.get('block_device_allocate_retries_interval', '10') }}
 
 resume_guests_state_on_host_boot = {{ compute.get('resume_guests_state_on_host_boot', True) }}
 service_down_time = 90

--- a/nova/files/mitaka/nova-controller.conf.Debian
+++ b/nova/files/mitaka/nova-controller.conf.Debian
@@ -73,8 +73,8 @@ rpc_response_timeout = {{ controller.message_queue.rpc_response_timeout }}
 rpc_thread_pool_size = 70
 report_interval = 5
 
-block_device_allocate_retries=600
-block_device_allocate_retries_interval=10
+block_device_allocate_retries={{ controller.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries_interval={{ controller.get('block_device_allocate_retries_interval', '10') }}
 
 {%- if controller.host is defined %}
 host={{ controller.host }}

--- a/nova/files/newton/nova-compute.conf.Debian
+++ b/nova/files/newton/nova-compute.conf.Debian
@@ -93,8 +93,8 @@ rpc_response_timeout = {{ compute.message_queue.rpc_response_timeout }}
 executor_thread_pool_size = 70
 report_interval = {{ compute.get('report_interval', '60') }}
 
-block_device_allocate_retries=600
-block_device_allocate_retries_interval=10
+block_device_allocate_retries={{ compute.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries_interval={{ compute.get('block_device_allocate_retries_interval', '10') }}
 
 resume_guests_state_on_host_boot = {{ compute.get('resume_guests_state_on_host_boot', True) }}
 service_down_time = 90

--- a/nova/files/newton/nova-controller.conf.Debian
+++ b/nova/files/newton/nova-controller.conf.Debian
@@ -80,8 +80,8 @@ rpc_response_timeout = {{ controller.message_queue.rpc_response_timeout }}
 rpc_thread_pool_size = 70
 report_interval = 5
 
-block_device_allocate_retries=600
-block_device_allocate_retries_interval=10
+block_device_allocate_retries={{ controller.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries_interval={{ controller.get('block_device_allocate_retries_interval', '10') }}
 
 {%- set rabbit_port = controller.message_queue.get('port', 5671 if controller.message_queue.get('ssl',{}).get('enabled', False) else 5672) %}
 

--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -757,7 +757,7 @@ max_concurrent_live_migrations = {{ compute.max_concurrent_live_migrations }}
 # * For any value > 0, total attempts are (value + 1)
 #  (integer value)
 #block_device_allocate_retries=60
-block_device_allocate_retries=600
+block_device_allocate_retries={{ controller.get('block_device_allocate_retries', '600') }}
 
 #
 # Number of greenthreads available for use to sync power states.
@@ -961,7 +961,7 @@ heal_instance_info_cache_interval = {{ compute.heal_instance_info_cache_interval
 #  (integer value)
 # Minimum value: 0
 #block_device_allocate_retries_interval=3
-block_device_allocate_retries_interval=10
+block_device_allocate_retries_interval={{ controller.get('block_device_allocate_retries_interval', '10') }}
 
 #
 # Interval between sending the scheduler a list of current instance UUIDs to

--- a/nova/files/ocata/nova-compute.conf.Debian
+++ b/nova/files/ocata/nova-compute.conf.Debian
@@ -757,7 +757,7 @@ max_concurrent_live_migrations = {{ compute.max_concurrent_live_migrations }}
 # * For any value > 0, total attempts are (value + 1)
 #  (integer value)
 #block_device_allocate_retries=60
-block_device_allocate_retries={{ controller.get('block_device_allocate_retries', '600') }}
+block_device_allocate_retries={{ compute.get('block_device_allocate_retries', '600') }}
 
 #
 # Number of greenthreads available for use to sync power states.
@@ -961,7 +961,7 @@ heal_instance_info_cache_interval = {{ compute.heal_instance_info_cache_interval
 #  (integer value)
 # Minimum value: 0
 #block_device_allocate_retries_interval=3
-block_device_allocate_retries_interval={{ controller.get('block_device_allocate_retries_interval', '10') }}
+block_device_allocate_retries_interval={{ compute.get('block_device_allocate_retries_interval', '10') }}
 
 #
 # Interval between sending the scheduler a list of current instance UUIDs to

--- a/nova/files/ocata/nova-controller.conf.Debian
+++ b/nova/files/ocata/nova-controller.conf.Debian
@@ -708,7 +708,7 @@ disk_allocation_ratio = {{ controller.disk_allocation_ratio }}
 # * For any value > 0, total attempts are (value + 1)
 #  (integer value)
 #block_device_allocate_retries=60
-block_device_allocate_retries=600
+block_device_allocate_retries={{ controller.get('block_device_allocate_retries', '600') }}
 
 #
 # Number of greenthreads available for use to sync power states.
@@ -910,7 +910,7 @@ block_device_allocate_retries=600
 #  (integer value)
 # Minimum value: 0
 #block_device_allocate_retries_interval=3
-block_device_allocate_retries_interval=10
+block_device_allocate_retries_interval={{ controller.get('block_device_allocate_retries_interval', '10') }}
 
 #
 # Interval between sending the scheduler a list of current instance UUIDs to

--- a/nova/files/pike/nova-compute.conf.Debian
+++ b/nova/files/pike/nova-compute.conf.Debian
@@ -761,7 +761,7 @@ max_concurrent_live_migrations = {{ compute.max_concurrent_live_migrations }}
 # * For any value > 0, total attempts are (value + 1)
 #  (integer value)
 #block_device_allocate_retries=60
-block_device_allocate_retries=600
+block_device_allocate_retries={{ compute.get('block_device_allocate_retries', '600') }}
 
 #
 # Number of greenthreads available for use to sync power states.
@@ -965,7 +965,7 @@ heal_instance_info_cache_interval = {{ compute.heal_instance_info_cache_interval
 #  (integer value)
 # Minimum value: 0
 #block_device_allocate_retries_interval=3
-block_device_allocate_retries_interval=10
+block_device_allocate_retries_interval={{ compute.get('block_device_allocate_retries_interval', '10') }}
 
 #
 # Interval between sending the scheduler a list of current instance UUIDs to

--- a/nova/files/pike/nova-controller.conf.Debian
+++ b/nova/files/pike/nova-controller.conf.Debian
@@ -721,7 +721,7 @@ instance_usage_audit = {{ controller.instance_usage_audit }}
 # * For any value > 0, total attempts are (value + 1)
 #  (integer value)
 #block_device_allocate_retries=60
-block_device_allocate_retries=600
+block_device_allocate_retries={{ controller.get('block_device_allocate_retries', '600') }}
 
 #
 # Number of greenthreads available for use to sync power states.
@@ -923,7 +923,7 @@ block_device_allocate_retries=600
 #  (integer value)
 # Minimum value: 0
 #block_device_allocate_retries_interval=3
-block_device_allocate_retries_interval=10
+block_device_allocate_retries_interval={{ controller.get('block_device_allocate_retries_interval', '10') }}
 
 #
 # Interval between sending the scheduler a list of current instance UUIDs to


### PR DESCRIPTION
Add missing parameters:
* block_device_allocate_retries
* block_device_allocate_retries_interval

into other conf files than just for queens release.

Hi, @epcim @Martin819 Could someone review it, please?